### PR TITLE
Improve toast fade transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -585,7 +585,9 @@
     t.style.padding='10px 14px'; t.style.background='rgba(0,0,0,.55)'; t.style.color='white';
     t.style.borderRadius='999px'; t.style.boxShadow='0 8px 20px rgba(0,0,0,.25)'; t.style.zIndex='9999'; t.style.fontWeight='700'; t.style.letterSpacing='.3px';
     document.body.appendChild(t);
-    setTimeout(function(){ t.style.opacity='0'; t.style.transition='opacity .6s'; t.remove(); }, 2000);
+    t.style.transition = 'opacity .6s';
+    setTimeout(function(){ t.style.opacity='0'; }, 2000);
+    setTimeout(function(){ t.remove(); }, 2600);
   }
   function toggleSound(){
     soundOn = !soundOn;


### PR DESCRIPTION
## Summary
- apply the opacity transition before triggering the toast fade
- remove toast elements after the fade completes to avoid abrupt disappearance

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68d66235cd98832d9af277f0ca81f37c